### PR TITLE
use androidFileProperties() instead of fileProperties()

### DIFF
--- a/examples/android-weather-app/src/main/kotlin/fr/ekito/myweatherapp/MainApplication.kt
+++ b/examples/android-weather-app/src/main/kotlin/fr/ekito/myweatherapp/MainApplication.kt
@@ -5,6 +5,7 @@ import com.joanzapata.iconify.Iconify
 import com.joanzapata.iconify.fonts.WeathericonsModule
 import fr.ekito.myweatherapp.di.roomWeatherApp
 import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidFileProperties
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
@@ -19,9 +20,9 @@ class MainApplication : Application() {
 
         // start Koin context
         startKoin {
-            fileProperties()
             androidLogger(Level.DEBUG)
             androidContext(this@MainApplication)
+            androidFileProperties()
             modules(roomWeatherApp)
         }
 


### PR DESCRIPTION
use **androidFileProperties()** instead of fileProperties()
because koin.properties in assets fold

Ref: 
https://insert-koin.io/docs/2.0/quick-references/starting-koin/#starting-koin-for-android
```KOTLIN
class MainApplication : Application() {

    override fun onCreate() {
        super.onCreate()

        startKoin {
            // use AndroidLogger as Koin Logger - default Level.INFO
            androidLogger()

            // use the Android context given there
            androidContext(this@MainApplication)

            // load properties from assets/koin.properties file
            androidFileProperties()

            // module list
            modules(myModules)
        }
    }
}
```
PS:
`androidFileProperties()` - use properties file from Android assets [[link]](https://insert-koin.io/docs/2.0/quick-references/starting-koin/#koinapplication-dsl-recap)